### PR TITLE
STYLE: Use "typename" for template parameters.

### DIFF
--- a/include/itkButterworthFilterFreqImageSource.hxx
+++ b/include/itkButterworthFilterFreqImageSource.hxx
@@ -26,7 +26,7 @@
 namespace itk
 {
 
-template <class TOutputImage>
+template <typename TOutputImage>
 ButterworthFilterFreqImageSource<TOutputImage>
 ::ButterworthFilterFreqImageSource():
   m_Cutoff( 0.4 ),
@@ -35,14 +35,14 @@ ButterworthFilterFreqImageSource<TOutputImage>
 }
 
 
-template <class TOutputImage>
+template <typename TOutputImage>
 ButterworthFilterFreqImageSource<TOutputImage>
 ::~ButterworthFilterFreqImageSource()
 {
 }
 
 
-template <class TOutputImage>
+template <typename TOutputImage>
 void
 ButterworthFilterFreqImageSource<TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const

--- a/include/itkPhaseSymmetryImageFilter.h
+++ b/include/itkPhaseSymmetryImageFilter.h
@@ -62,7 +62,7 @@ namespace itk
  *
  * \ingroup PhaseSymmetry
  */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 class PhaseSymmetryImageFilter : public ImageToImageFilter<TInputImage,TOutputImage>
 {
 public:

--- a/include/itkPhaseSymmetryImageFilter.hxx
+++ b/include/itkPhaseSymmetryImageFilter.hxx
@@ -26,7 +26,7 @@
 namespace itk
 {
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 ::PhaseSymmetryImageFilter()
 {
@@ -91,7 +91,7 @@ PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 ::Initialize( void )
 {
@@ -187,7 +187,7 @@ void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 ::GenerateData( void )
 {
@@ -375,7 +375,7 @@ void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 ::GenerateInputRequestedRegion()
 {
@@ -417,7 +417,7 @@ void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 /**
 * GenerateData Performs the accumulation
 */
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 ::GenerateOutputInformation( void )
 {
@@ -468,7 +468,7 @@ void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 }
 
 
-template <class TInputImage, class TOutputImage>
+template <typename TInputImage, typename TOutputImage>
 void PhaseSymmetryImageFilter<TInputImage,TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const
 {

--- a/include/itkSteerableFilterFreqImageSource.hxx
+++ b/include/itkSteerableFilterFreqImageSource.hxx
@@ -27,7 +27,7 @@
 namespace itk
 {
 
-template <class TOutputImage>
+template <typename TOutputImage>
 SteerableFilterFreqImageSource<TOutputImage>
 ::SteerableFilterFreqImageSource()
 {
@@ -44,14 +44,14 @@ SteerableFilterFreqImageSource<TOutputImage>
 }
 
 
-template <class TOutputImage>
+template <typename TOutputImage>
 SteerableFilterFreqImageSource<TOutputImage>
 ::~SteerableFilterFreqImageSource()
 {
 }
 
 
-template <class TOutputImage>
+template <typename TOutputImage>
 void SteerableFilterFreqImageSource<TOutputImage>
 ::PrintSelf(std::ostream& os, Indent indent) const
 {


### PR DESCRIPTION
As discussed in:
http://review.source.kitware.com/#/c/12655/

the use of the template keyword "class" was substituted by "typename" in
the toolkit for the reasons stated in that topic.