### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/app/main2.cxx
+++ b/app/main2.cxx
@@ -292,7 +292,7 @@ int main(int argc, char* argv[])
     {
     for(int j=0; j < 2; j++)
       {
-      wavelengths(i,j) = atof(wavelengthsVS[idx].c_str());
+      wavelengths(i,j) = std::stod(wavelengthsVS[idx].c_str());
       idx++;
       }
     }
@@ -302,22 +302,22 @@ int main(int argc, char* argv[])
     {
     for(int j=0; j < 2; j++)
       {
-      orientations(i,j) = atof(orientationsVS[idx].c_str());
+      orientations(i,j) = std::stod(orientationsVS[idx].c_str());
       idx++;
       }
     }
 
   double sigma=0;
-  sigma = atof( sigmaS.c_str() );
+  sigma = std::stod( sigmaS.c_str() );
 
   double anglebandwidth = 0;
-  anglebandwidth = atof( angular_bandwidthS.c_str() );
+  anglebandwidth = std::stod( angular_bandwidthS.c_str() );
 
   int polarity = 0;
-  polarity =int( atof( polarityS.c_str() ) );
+  polarity =int( std::stod( polarityS.c_str() ) );
 
   double noiseT = 0;
-  noiseT = atof( ntS.c_str() );
+  noiseT = std::stod( ntS.c_str() );
 
   reader->SetFileName(infile.c_str());
   try

--- a/app/main3.cxx
+++ b/app/main3.cxx
@@ -321,7 +321,7 @@ int main(int argc, char* argv[])
   {
     for(int j=0; j < 3; j++)
     {
-      wavelengths(i,j) = atof(wavelengthsVS[idx].c_str());
+      wavelengths(i,j) = std::stod(wavelengthsVS[idx].c_str());
       idx++;
     }
   }
@@ -332,26 +332,26 @@ int main(int argc, char* argv[])
   {
     for(int j=0; j < 3; j++)
     {
-      orientations(i,j) = atof(orientationsVS[idx].c_str());
+      orientations(i,j) = std::stod(orientationsVS[idx].c_str());
       idx++;
     }
   }
   
 
   double sigma=0;
-  sigma = atof( sigmaS.c_str() );
+  sigma = std::stod( sigmaS.c_str() );
 
 
   double anglebandwidth=0;
-  anglebandwidth = atof( angular_bandwidthS.c_str() );
+  anglebandwidth = std::stod( angular_bandwidthS.c_str() );
 
 
   int polarity=0;
-  polarity =int( atof( polarityS.c_str() ) );
+  polarity =int( std::stod( polarityS.c_str() ) );
 
 
   double noiseT=0;
-  noiseT = atof( ntS.c_str() );
+  noiseT = std::stod( ntS.c_str() );
 
   reader->SetFileName(infile.c_str());
   try

--- a/test/itkSinusoidImageSourceTest.cxx
+++ b/test/itkSinusoidImageSourceTest.cxx
@@ -32,22 +32,22 @@ int itkSinusoidImageSourceTest(int argc, char* argv[] )
   double xFrequency = 0.02;
   if( argc > 2 )
     {
-    xFrequency = atof( argv[2] );
+    xFrequency = std::stod( argv[2] );
     }
   double yFrequency = 0.1;
   if( argc > 3 )
     {
-    yFrequency = atof( argv[3] );
+    yFrequency = std::stod( argv[3] );
     }
   double zFrequency = 0.2;
   if( argc > 4 )
     {
-    zFrequency = atof( argv[4] );
+    zFrequency = std::stod( argv[4] );
     }
   double phaseOffset = 0.2;
   if( argc > 5 )
     {
-    phaseOffset = atof( argv[5] );
+    phaseOffset = std::stod( argv[5] );
     }
 
   // This can be changed!


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/