### PR TITLE
COMP: Use and move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkButterworthFilterFreqImageSource.h
+++ b/include/itkButterworthFilterFreqImageSource.h
@@ -32,6 +32,8 @@ class ButterworthFilterFreqImageSource:
   public GenerateImageSource< TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ButterworthFilterFreqImageSource);
+
   /** Standard class type alias. */
   using Self = ButterworthFilterFreqImageSource;
   using Superclass = GenerateImageSource< TOutputImage >;
@@ -73,8 +75,6 @@ protected:
   virtual void ThreadedGenerateData(const OutputImageRegionType& outputRegionForThread, ThreadIdType threadId) ITK_OVERRIDE;
 
 private:
-  ButterworthFilterFreqImageSource(const ButterworthFilterFreqImageSource&); //purposely not implemented
-  void operator=(const ButterworthFilterFreqImageSource&); //purposely not implemented
 
   double m_Cutoff;
   double m_Order;

--- a/include/itkLogGaborFreqImageSource.h
+++ b/include/itkLogGaborFreqImageSource.h
@@ -32,6 +32,8 @@ class LogGaborFreqImageSource:
   public GenerateImageSource< TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LogGaborFreqImageSource);
+
   /** Standard class type alias. */
   using Self = LogGaborFreqImageSource;
   using Superclass = GenerateImageSource< TOutputImage >;
@@ -76,9 +78,6 @@ private:
 
   // The wavelengths in each direction
   ArrayType m_Wavelengths;
-
-  LogGaborFreqImageSource( const LogGaborFreqImageSource& ); //purposely not implemented
-  void operator=( const LogGaborFreqImageSource& ); //purposely not implemented
 };
 
 } // end namespace itk

--- a/include/itkPhaseSymmetryImageFilter.h
+++ b/include/itkPhaseSymmetryImageFilter.h
@@ -66,6 +66,8 @@ template <typename TInputImage, typename TOutputImage>
 class PhaseSymmetryImageFilter : public ImageToImageFilter<TInputImage,TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseSymmetryImageFilter);
+
   /** Standard class type alias. */
   using Self = PhaseSymmetryImageFilter;
   using Superclass = ImageToImageFilter<TInputImage,TOutputImage>;
@@ -174,8 +176,6 @@ protected:
   using AbsImageFilterType = AbsImageFilter< FloatImageType, FloatImageType >;
 
 private:
-  PhaseSymmetryImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
 
   MatrixType m_Wavelengths;
   MatrixType m_Orientations;

--- a/include/itkSinusoidImageSource.h
+++ b/include/itkSinusoidImageSource.h
@@ -42,6 +42,8 @@ class SinusoidImageSource :
     public ParametricImageSource< TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SinusoidImageSource);
+
   /** Standard class type alias. */
   using Self = SinusoidImageSource;
   using Superclass = ParametricImageSource< TOutputImage >;
@@ -98,8 +100,6 @@ protected:
   virtual void GenerateData() ITK_OVERRIDE;
 
 private:
-  SinusoidImageSource(const SinusoidImageSource &); //purposely not implemented
-  void operator=(const SinusoidImageSource &);      //purposely not implemented
 
   /** Parameters for the Sinusoid. */
 

--- a/include/itkSinusoidSpatialFunction.h
+++ b/include/itkSinusoidSpatialFunction.h
@@ -45,6 +45,8 @@ class SinusoidSpatialFunction:
   public SpatialFunction< TOutput, VImageDimension, TInput >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SinusoidSpatialFunction);
+
   /** Standard class type alias. */
   using Self = SinusoidSpatialFunction;
   using Superclass = SpatialFunction< TOutput, VImageDimension, TInput >;
@@ -82,8 +84,6 @@ protected:
   void PrintSelf(std::ostream & os, Indent indent) const;
 
 private:
-  SinusoidSpatialFunction(const Self &); //purposely not implemented
-  void operator=(const Self &);          //purposely not implemented
 
   /** The spatial frequency in each direction. */
   ArrayType m_Frequency;

--- a/include/itkSteerableFilterFreqImageSource.h
+++ b/include/itkSteerableFilterFreqImageSource.h
@@ -34,6 +34,8 @@ template <typename TOutputImage>
 class SteerableFilterFreqImageSource : public ImageSource<TOutputImage>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SteerableFilterFreqImageSource);
+
   /** Standard class type alias. */
   using Self = SteerableFilterFreqImageSource;
   using Superclass = ImageSource<TOutputImage>;
@@ -127,8 +129,6 @@ protected:
   virtual void GenerateOutputInformation();
 
 private:
-  SteerableFilterFreqImageSource(const SteerableFilterFreqImageSource&); //purposely not implemented
-  void operator=(const SteerableFilterFreqImageSource&); //purposely not implemented
 
   SizeValueType  m_Size[NDimensions];    //size of the output image
   SpacingType    m_Spacing;   //spacing


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_ASSIGN` macro to enhance consistency across
the toolkit when disallowing the copy constructor and the assign operator.

Move the `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable