### PR TITLE
avoid build error where SpacePrecisionType not found 

### DIFF
--- a/include/itkSinusoidSpatialFunction.h
+++ b/include/itkSinusoidSpatialFunction.h
@@ -20,6 +20,8 @@
 
 #include "itkSpatialFunction.h"
 #include "itkFixedArray.h"
+#include "itkFloatTypes.h"
+
 
 namespace itk
 {
@@ -38,6 +40,7 @@ namespace itk
  * \ingroup SpatialFunctions
  * \ingroup PhaseSymmetry
  */
+
 template< typename TOutput = double,
           unsigned int VImageDimension = 3,
           typename TInput = Point< SpacePrecisionType, VImageDimension > >


### PR DESCRIPTION
Strange issue when I tried to compile resolved by adding in the above header file. 
