### PR TITLE
BUG: Propagate input image index to filter bank

### DIFF
--- a/include/itkPhaseSymmetryImageFilter.hxx
+++ b/include/itkPhaseSymmetryImageFilter.hxx
@@ -192,6 +192,9 @@ PhaseSymmetryImageFilter<TInputImage,TOutputImage>
       fftShiftFilter->Update();
       tempStack.push_back(fftShiftFilter->GetOutput());
       tempStack[o]->DisconnectPipeline();
+      typename FloatImageType::RegionType region = tempStack[o]->GetBufferedRegion();
+      region.SetIndex(inputIndex);
+      tempStack[o]->SetRegions(region);
       }
     m_FilterBank.push_back(tempStack);
     }

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='itk-phasesymmetry',
-    version='1.0.1',
+    version='1.0.2',
     author='Charles Hatt',
     author_email='hatt@wisc.edu',
     packages=['itk'],


### PR DESCRIPTION
This is used in a MultiplyImageFilter with images derived by the input
image in GenerateData(). Intended to address:

  Requested region is (at least partially) outside the largest possible region.