### PR TITLE
BUG: Disable the module examples since they require SEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,3 @@ if(NOT ITK_SOURCE_DIR)
 else()
   itk_module_impl()
 endif()
-
-itk_module_examples()


### PR DESCRIPTION
CMake configuration of the module's examples fails the Doxygen build.
Disable them since they require the SlicerExecutionModel, which is not
available by default.