### PR TITLE
COMP: Remove of compiler warning

### DIFF
--- a/include/itkPhaseSymmetryImageFilter.hxx
+++ b/include/itkPhaseSymmetryImageFilter.hxx
@@ -58,7 +58,7 @@ PhaseSymmetryImageFilter<TInputImage, TOutputImage>::PhaseSymmetryImageFilter()
 
   // Create 2 initialze wavelengths
   m_Wavelengths.SetSize(2, InputImageDimension);
-  for (int i = 0; i < InputImageDimension; i++)
+  for (unsigned int i = 0; i < InputImageDimension; i++)
   {
     m_Wavelengths(0, i) = 10.0;
     m_Wavelengths(1, i) = 20.0;
@@ -66,9 +66,9 @@ PhaseSymmetryImageFilter<TInputImage, TOutputImage>::PhaseSymmetryImageFilter()
 
   // Set basic orientations
   m_Orientations.SetSize(InputImageDimension, InputImageDimension);
-  for (int i = 0; i < InputImageDimension; i++)
+  for (unsigned int i = 0; i < InputImageDimension; i++)
   {
-    for (int j = 0; j < InputImageDimension; j++)
+    for (unsigned int j = 0; j < InputImageDimension; j++)
     {
       if (i == j)
       {

--- a/include/itkSteerableFilterFreqImageSource.hxx
+++ b/include/itkSteerableFilterFreqImageSource.hxx
@@ -121,7 +121,7 @@ SteerableFilterFreqImageSource<TOutputImage>::DynamicThreadedGenerateData(
     radius = 0;
     dotProduct = 0;
 
-    for (int i = 0; i < TOutputImage::ImageDimension; i++)
+    for (unsigned int i = 0; i < TOutputImage::ImageDimension; i++)
     {
       dist[i] = (double(index[i]) - centerPoint[i]) / double(m_Size[i]);
       dotProduct = dotProduct + m_Orientation[i] * dist[i];


### PR DESCRIPTION
This patch fixes a compiler warning regarding the comparison of a signed int and unsigned int. Changing the iteration variable (i) from signed to unsigned fixes this.