### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkButterworthFilterFreqImageSource.h
+++ b/include/itkButterworthFilterFreqImageSource.h
@@ -31,7 +31,7 @@ template <typename TOutputImage>
 class ButterworthFilterFreqImageSource : public GenerateImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ButterworthFilterFreqImageSource);
+  ITK_DISALLOW_COPY_AND_MOVE(ButterworthFilterFreqImageSource);
 
   /** Standard class type alias. */
   using Self = ButterworthFilterFreqImageSource;

--- a/include/itkLogGaborFreqImageSource.h
+++ b/include/itkLogGaborFreqImageSource.h
@@ -31,7 +31,7 @@ template <typename TOutputImage>
 class LogGaborFreqImageSource : public GenerateImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LogGaborFreqImageSource);
+  ITK_DISALLOW_COPY_AND_MOVE(LogGaborFreqImageSource);
 
   /** Standard class type alias. */
   using Self = LogGaborFreqImageSource;

--- a/include/itkPhaseSymmetryImageFilter.h
+++ b/include/itkPhaseSymmetryImageFilter.h
@@ -66,7 +66,7 @@ template <typename TInputImage, typename TOutputImage>
 class PhaseSymmetryImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseSymmetryImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(PhaseSymmetryImageFilter);
 
   /** Standard class type alias. */
   using Self = PhaseSymmetryImageFilter;

--- a/include/itkSinusoidImageSource.h
+++ b/include/itkSinusoidImageSource.h
@@ -41,7 +41,7 @@ template <typename TOutputImage>
 class SinusoidImageSource : public ParametricImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SinusoidImageSource);
+  ITK_DISALLOW_COPY_AND_MOVE(SinusoidImageSource);
 
   /** Standard class type alias. */
   using Self = SinusoidImageSource;

--- a/include/itkSinusoidSpatialFunction.h
+++ b/include/itkSinusoidSpatialFunction.h
@@ -47,7 +47,7 @@ template <typename TOutput = double,
 class SinusoidSpatialFunction : public SpatialFunction<TOutput, VImageDimension, TInput>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SinusoidSpatialFunction);
+  ITK_DISALLOW_COPY_AND_MOVE(SinusoidSpatialFunction);
 
   /** Standard class type alias. */
   using Self = SinusoidSpatialFunction;

--- a/include/itkSteerableFilterFreqImageSource.h
+++ b/include/itkSteerableFilterFreqImageSource.h
@@ -34,7 +34,7 @@ template <typename TOutputImage>
 class SteerableFilterFreqImageSource : public ImageSource<TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SteerableFilterFreqImageSource);
+  ITK_DISALLOW_COPY_AND_MOVE(SteerableFilterFreqImageSource);
 
   /** Standard class type alias. */
   using Self = SteerableFilterFreqImageSource;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.