### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkButterworthFilterFreqImageSource.hxx
+++ b/include/itkButterworthFilterFreqImageSource.hxx
@@ -19,7 +19,6 @@
 #ifndef itkButterworthFilterFreqImageSource_hxx
 #define itkButterworthFilterFreqImageSource_hxx
 
-#include "itkButterworthFilterFreqImageSource.h"
 #include "itkImageRegionIteratorWithIndex.h"
 
 

--- a/include/itkLogGaborFreqImageSource.hxx
+++ b/include/itkLogGaborFreqImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef itkLogGaborFreqImageSource_hxx
 #define itkLogGaborFreqImageSource_hxx
 
-#include "itkLogGaborFreqImageSource.h"
 #include "itkImageRegionIteratorWithIndex.h"
 
 namespace itk

--- a/include/itkPhaseSymmetryImageFilter.hxx
+++ b/include/itkPhaseSymmetryImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkPhaseSymmetryImageFilter_hxx
 #define itkPhaseSymmetryImageFilter_hxx
 
-#include "itkPhaseSymmetryImageFilter.h"
 #include <string>
 #include <sstream>
 

--- a/include/itkSinusoidImageSource.hxx
+++ b/include/itkSinusoidImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSinusoidImageSource_hxx
 #define itkSinusoidImageSource_hxx
 
-#include "itkSinusoidImageSource.h"
 #include "itkSinusoidSpatialFunction.h"
 #include "itkImageRegionIterator.h"
 #include "itkProgressReporter.h"

--- a/include/itkSinusoidSpatialFunction.hxx
+++ b/include/itkSinusoidSpatialFunction.hxx
@@ -20,7 +20,6 @@
 
 #include <cmath>
 #include "vnl/vnl_math.h"
-#include "itkSinusoidSpatialFunction.h"
 
 namespace itk
 {

--- a/include/itkSteerableFilterFreqImageSource.hxx
+++ b/include/itkSteerableFilterFreqImageSource.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSteerableFilterFreqImageSource_hxx
 #define itkSteerableFilterFreqImageSource_hxx
 
-#include "itkSteerableFilterFreqImageSource.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkProgressReporter.h"
 #include "itkObjectFactory.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

