### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassM…

### DIFF
--- a/include/itkButterworthFilterFreqImageSource.h
+++ b/include/itkButterworthFilterFreqImageSource.h
@@ -40,7 +40,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(ButterworthFilterFreqImageSource, GenerateImageSource);
+  itkOverrideGetNameOfClassMacro(ButterworthFilterFreqImageSource);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkButterworthFilterFreqImageSource.h
+++ b/include/itkButterworthFilterFreqImageSource.h
@@ -46,7 +46,7 @@ public:
   itkNewMacro(Self);
 
   /** Dimensionality of the output image. */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   using OutputImageType = TOutputImage;
   using SpacingType = typename TOutputImage::SpacingType;

--- a/include/itkLogGaborFreqImageSource.h
+++ b/include/itkLogGaborFreqImageSource.h
@@ -52,7 +52,7 @@ public:
   using ArrayType = FixedArray<double, ImageDimension>;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LogGaborFreqImageSource, GenerateImageSource);
+  itkOverrideGetNameOfClassMacro(LogGaborFreqImageSource);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkLogGaborFreqImageSource.h
+++ b/include/itkLogGaborFreqImageSource.h
@@ -40,7 +40,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Dimensionality of the output image */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   using OutputImageType = TOutputImage;
   using OutputImageRegionType = typename TOutputImage::RegionType;

--- a/include/itkPhaseSymmetryImageFilter.h
+++ b/include/itkPhaseSymmetryImageFilter.h
@@ -80,8 +80,8 @@ public:
   /** Run-time type information (and related methods). */
   itkOverrideGetNameOfClassMacro(PhaseSymmetryImageFilter);
 
-  itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
-  itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int InputImageDimension = TInputImage::ImageDimension;
+  static constexpr unsigned int OutputImageDimension = TOutputImage::ImageDimension;
 
   /** Some convenient type alias. */
   using InputImageType = TInputImage;

--- a/include/itkPhaseSymmetryImageFilter.h
+++ b/include/itkPhaseSymmetryImageFilter.h
@@ -78,7 +78,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(PhaseSymmetryImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(PhaseSymmetryImageFilter);
 
   itkStaticConstMacro(InputImageDimension, unsigned int, TInputImage::ImageDimension);
   itkStaticConstMacro(OutputImageDimension, unsigned int, TOutputImage::ImageDimension);

--- a/include/itkSinusoidImageSource.h
+++ b/include/itkSinusoidImageSource.h
@@ -53,7 +53,7 @@ public:
   using OutputImageType = TOutputImage;
 
   /** Dimensionality of the output image */
-  itkStaticConstMacro(ImageDimension, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int ImageDimension = TOutputImage::ImageDimension;
 
   /** Type used to store Sinusoid parameters. */
   using ArrayType = FixedArray<double, ImageDimension>;

--- a/include/itkSinusoidImageSource.h
+++ b/include/itkSinusoidImageSource.h
@@ -67,7 +67,7 @@ public:
   using ParametersType = typename Superclass::ParametersType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SinusoidImageSource, ParametricImageSource);
+  itkOverrideGetNameOfClassMacro(SinusoidImageSource);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkSinusoidSpatialFunction.h
+++ b/include/itkSinusoidSpatialFunction.h
@@ -59,7 +59,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SinusoidSpatialFunction, SpatialFunction);
+  itkOverrideGetNameOfClassMacro(SinusoidSpatialFunction);
 
   /** Input type for the function. */
   using InputType = typename Superclass::InputType;

--- a/include/itkSteerableFilterFreqImageSource.h
+++ b/include/itkSteerableFilterFreqImageSource.h
@@ -75,7 +75,7 @@ public:
   using SizeValueType = typename TOutputImage::SizeValueType;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SteerableFilterFreqImageSource, ImageSource);
+  itkOverrideGetNameOfClassMacro(SteerableFilterFreqImageSource);
 
   /** Method for creation through the object factory. */
   itkNewMacro(Self);

--- a/include/itkSteerableFilterFreqImageSource.h
+++ b/include/itkSteerableFilterFreqImageSource.h
@@ -63,7 +63,7 @@ public:
   using RangeType = std::vector<std::vector<double>>;
 
   /** Dimensionality of the output image */
-  itkStaticConstMacro(NDimensions, unsigned int, TOutputImage::ImageDimension);
+  static constexpr unsigned int NDimensions = TOutputImage::ImageDimension;
 
   /** Type used to store gaussian parameters. */
 


### PR DESCRIPTION
…acro

Added two new macro's, intended to replace the old 'itkTypeMacro' and 'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual 'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro', 'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337